### PR TITLE
CyberChef application

### DIFF
--- a/apps/cyberchef/icon.svg
+++ b/apps/cyberchef/icon.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="400"
+   height="400"
+   viewBox="0 0 400 399.99999"
+   id="svg4819"
+   sodipodi:docname="cyberchef_hat.svg">
+  <defs
+     id="defs4821">
+    <filter
+       style="color-interpolation-filters:sRGB"
+       id="filter4682">
+      <feFlood
+         flood-opacity="0.498039"
+         flood-color="rgb(0,0,0)"
+         result="flood"
+         id="feFlood4684" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite4686" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="5"
+         result="blur"
+         id="feGaussianBlur4688" />
+      <feOffset
+         dx="1.34615e-014"
+         dy="0.7"
+         result="offset"
+         id="feOffset4690" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite4692" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     showgrid="false"
+     units="px"
+     showguides="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata4824">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(-61.812519,-579.37011)">
+    <circle
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="path5494-5-0"
+       cx="209.06097"
+       cy="843.2403"
+       r="0" />
+    <g
+       id="g4673"
+       style="filter:url(#filter4682)"
+       transform="translate(5.1770318,2.0203049)">
+      <path
+         id="rect5513"
+         d="m 243.66981,877.59676 0,32.00949 97.94463,0 0,-32.00949 -97.94463,0 z"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         id="path5516"
+         d="m 243.66981,877.59676 -97.94463,0 0,32.00949 97.94463,0 0,-32.00949 z"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         id="path5432"
+         d="m 252.43415,634.65787 c -2.93079,0.0237 -5.85751,0.22598 -8.76434,0.60581 2.9e-4,92.54556 0,151.78177 0,246.9062 l 102.82518,0 0,-51.59276 c 0.34138,-2.19919 0.64564,-4.39387 0.82997,-6.13864 l 0.74658,-7.06246 6.41143,-2.55609 6.41143,-2.5581 9.34811,7.55758 c 5.14171,4.15711 10.34711,7.56009 11.56798,7.56361 3.05362,0.0103 24.90114,-22.4949 24.90114,-25.64946 0,-1.33375 -3.32577,-6.68709 -7.38833,-11.89487 l -7.38636,-9.4676 2.32909,-5.44225 c 1.28072,-2.99325 2.66205,-5.81504 3.06771,-6.26947 0.40565,-0.45443 6.4466,-1.77039 13.4245,-2.92441 l 12.68785,-2.09721 0.31968,-17.45587 c 0.19141,-10.42474 -0.1393,-17.92314 -0.82203,-18.61518 -0.62875,-0.63732 -6.64398,-1.99532 -13.36493,-3.01699 l -12.21726,-1.85568 -2.69443,-6.71426 -2.69047,-6.71226 7.36849,-9.55615 c 4.05209,-5.256 7.36649,-10.33897 7.36649,-11.2951 0,-2.04511 -22.89779,-25.96343 -24.85547,-25.96343 -0.73476,0 -5.85983,3.4567 -11.38928,7.68437 l -10.05298,7.6884 -6.15927,-2.5883 -5.96467,-2.50376 c -0.0655,-0.0303 -0.13101,-0.0605 -0.19658,-0.0906 l -1.89623,-12.34168 c -1.04342,-6.79095 -2.4584,-13.03053 -3.14516,-13.86931 -0.96141,-1.17423 -9.08067,-1.71556 -17.20305,-1.66447 -8.12235,0.0511 -16.24958,0.69142 -17.22093,1.87782 -0.69477,0.84854 -1.89525,5.90378 -2.8493,11.68555 -13.78021,-15.03842 -33.09617,-23.61037 -53.34456,-23.67301 z"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         sodipodi:nodetypes="cccccccccccscccscccscccccsscccccssscccc" />
+      <path
+         id="path5490"
+         d="m 243.66981,904.03117 0,16.911 102.82518,0 0,-16.911 -102.82518,0 z"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         id="path5488"
+         d="m 243.66981,635.26335 a 73.110297,74.107784 0 0 0 -50.24705,29.88411 73.110297,74.107784 0 0 0 -24.78797,-4.48825 73.110297,74.107784 0 0 0 -73.109015,74.10849 73.110297,74.107784 0 0 0 44.891955,68.35225 l 0,79.0496 103.25208,0 0,-246.9062 z"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         id="path5492"
+         d="m 243.66981,904.03117 -103.25208,0 0,16.911 103.25208,0 0,-16.911 z"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         id="path4473-2"
+         d="m 141.92964,901.472 204.28572,0"
+         style="fill:none;fill-rule:evenodd;stroke:none;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/apps/cyberchef/index.js
+++ b/apps/cyberchef/index.js
@@ -1,0 +1,40 @@
+import meeseOS from "meeseOS";
+import { name as applicationName } from "./metadata.json";
+
+// Creates the internal callback function when MeeseOS launches an application
+// Note the first argument is the "name" taken from your metadata.json file
+const register = (core, args, options, metadata) => {
+	const url = "https://gchq.github.io/CyberChef/";
+
+	// Create a new Application instance
+	const proc = core.make("meeseOS/application", {
+		args,
+		options,
+		metadata,
+	});
+
+	// Create a new Window instance
+	const win = proc.createWindow({
+		id: `${proc.metadata.name}Window`,
+		title: metadata.title,
+		icon: proc.resource(proc.metadata.icon),
+		dimension: { width: 1075, height: 620 },
+		position: { left: 600, top: 200 },
+	});
+
+	win.on("destroy", () => proc.destroy());
+	win.render(($content) => {
+		const iframe = document.createElement("iframe");
+		iframe.style.width = "100%";
+		iframe.style.height = "100%";
+		iframe.style.backgroundColor = "white";
+		iframe.src = proc.resource(url);
+		iframe.setAttribute("border", "0");
+		$content.appendChild(iframe);
+	});
+
+	return proc;
+};
+
+// Creates the internal callback function when OS.js launches an application
+meeseOS.register(applicationName, register);

--- a/apps/cyberchef/index.js
+++ b/apps/cyberchef/index.js
@@ -1,5 +1,5 @@
-import meeseOS from "meeseOS";
 import { name as applicationName } from "./metadata.json";
+import meeseOS from "meeseOS";
 
 // Creates the internal callback function when MeeseOS launches an application
 // Note the first argument is the "name" taken from your metadata.json file

--- a/apps/cyberchef/metadata.json
+++ b/apps/cyberchef/metadata.json
@@ -1,0 +1,9 @@
+{
+  "type": "application",
+  "name": "@meeseOS/cyberchef",
+  "icon": "icon.svg",
+  "category": "utilities",
+  "title": "CyberChef",
+  "description": "The Cyber Swiss Army Knife - a web app for encryption, encoding, compression and data analysis.",
+  "files": ["main.js"]
+}

--- a/apps/cyberchef/package.json
+++ b/apps/cyberchef/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@meeseOS/cyberchef",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "npm run eslint",
+    "eslint": "eslint *.js",
+    "build": "webpack",
+    "watch": "webpack --watch",
+    "prepublishOnly": "npm run test && rm ./dist/* && npm run build"
+  },
+  "files": [
+    "dist/",
+    "metadata.json"
+  ],
+  "devDependencies": {
+    "@meeseOS/eslint-config": "workspace:*",
+    "@babel/core": "^7.17.2",
+    "@babel/plugin-transform-runtime": "^7.17.0",
+    "@babel/preset-env": "^7.16.11",
+    "@babel/runtime": "^7.17.2",
+    "babel-loader": "^8.2.3",
+    "copy-webpack-plugin": "^10.2.4",
+    "eslint": "^8.18.0",
+    "webpack": "^5.68.0",
+    "webpack-cli": "^4.9.2"
+  },
+  "dependencies": {},
+  "meeseOS": {
+    "type": "package"
+  },
+  "eslintConfig": {
+    "env": {
+      "browser": true,
+      "node": true
+    },
+    "parserOptions": {
+      "sourceType": "module"
+    },
+    "extends": "@meeseOS/eslint-config"
+  },
+  "babel": {
+    "presets": [
+      "@babel/preset-env"
+    ],
+    "plugins": [
+      "@babel/plugin-transform-runtime"
+    ]
+  }
+}

--- a/apps/cyberchef/webpack.config.js
+++ b/apps/cyberchef/webpack.config.js
@@ -1,0 +1,32 @@
+const path = require("path");
+const mode = process.env.NODE_ENV || "development";
+const minimize = mode === "production";
+const CopyWebpackPlugin = require("copy-webpack-plugin");
+
+module.exports = {
+	mode,
+	devtool: "source-map",
+	entry: [path.resolve(__dirname, "index.js")],
+	optimization: {
+		minimize,
+	},
+	externals: {
+		meeseOS: "MeeseOS",
+	},
+	plugins: [
+		new CopyWebpackPlugin({
+			patterns: ["icon.svg"],
+		}),
+	],
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				exclude: /node_modules/,
+				use: {
+					loader: "babel-loader",
+				},
+			},
+		],
+	},
+};

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -5,6 +5,30 @@ importers:
   .:
     specifiers: {}
 
+  ../../apps/cyberchef:
+    specifiers:
+      '@babel/core': ^7.17.2
+      '@babel/plugin-transform-runtime': ^7.17.0
+      '@babel/preset-env': ^7.16.11
+      '@babel/runtime': ^7.17.2
+      '@meeseOS/eslint-config': workspace:*
+      babel-loader: ^8.2.3
+      copy-webpack-plugin: ^10.2.4
+      eslint: ^8.18.0
+      webpack: ^5.68.0
+      webpack-cli: ^4.9.2
+    devDependencies:
+      '@babel/core': 7.17.10
+      '@babel/plugin-transform-runtime': 7.17.10
+      '@babel/preset-env': 7.17.10
+      '@babel/runtime': 7.17.9
+      '@meeseOS/eslint-config': link:../../development/eslint
+      babel-loader: 8.2.5_webpack-cli@4.9.2
+      copy-webpack-plugin: 10.2.4_webpack-cli@4.9.2
+      eslint: 8.18.0
+      webpack: 5.72.1_webpack-cli@4.9.2
+      webpack-cli: 4.9.2
+
   ../../apps/filemanager:
     specifiers:
       '@babel/core': ^7.17.2
@@ -1146,6 +1170,7 @@ importers:
       '@meeseOS/We10X-icons': workspace:*
       '@meeseOS/cli': workspace:*
       '@meeseOS/client': workspace:*
+      '@meeseOS/cyberchef': workspace:*
       '@meeseOS/dialogs': workspace:*
       '@meeseOS/dynamic-wallpapers': workspace:*
       '@meeseOS/eslint-config': workspace:*
@@ -1194,6 +1219,7 @@ importers:
       '@meeseOS/We10X-icons': link:../frontend/We10X-icons
       '@meeseOS/cli': link:../development/cli
       '@meeseOS/client': link:../frontend/client
+      '@meeseOS/cyberchef': link:../apps/cyberchef
       '@meeseOS/dialogs': link:../frontend/dialogs
       '@meeseOS/dynamic-wallpapers': link:../frontend/dynamic-wallpapers
       '@meeseOS/filemanager': link:../apps/filemanager

--- a/rush.json
+++ b/rush.json
@@ -469,6 +469,10 @@
       "projectFolder": "frontend/cursor-effects"
     },
     {
+      "packageName": "@meeseOS/cyberchef",
+      "projectFolder": "apps/cyberchef"
+    },
+    {
       "packageName": "@meeseOS/dialogs",
       "projectFolder": "frontend/dialogs"
     },

--- a/website/package.json
+++ b/website/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@meeseOS/cli": "workspace:*",
     "@meeseOS/client": "workspace:*",
+    "@meeseOS/cyberchef": "workspace:*",
     "@meeseOS/dialogs": "workspace:*",
     "@meeseOS/dynamic-wallpapers": "workspace:*",
     "@meeseOS/filemanager": "workspace:*",


### PR DESCRIPTION
Introduces the CyberChef application, for use in various cyber-related activities. Ideally there will eventually be a dedicated application marketplace like OS.js intended and like aOS has implemented, and this will reside somewhere amongst the `Cyber` category as a full-fledged application tied to the GitHub repository instead of as an embedded iframe.

The iframe application currently functions as intended, with the exception of unwanted console output from the cross-origin iframe. This is currently unable to be muted on the client-side and results in a DOMException, so [a ticket](https://github.com/gchq/CyberChef/issues/1420) has been opened in the official CyberChef repository requesting support for output suppression.

Eventually this will not matter if the transition to the dedicated application is introduced with an application marketplace, but for now this feature would be beneficial to not polluting the console.