### PR TITLE
fix(build): silence non-actionable webpack filesystem-cache warnings

### DIFF
--- a/apps/cyberchef/webpack.config.js
+++ b/apps/cyberchef/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const mode = process.env.NODE_ENV ?? "development";
 const minimize = mode === "production";
 const CopyWebpackPlugin = require("copy-webpack-plugin");
@@ -7,6 +7,7 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/apps/filemanager/webpack.config.js
+++ b/apps/filemanager/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const webpack = require("webpack");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
@@ -16,6 +16,7 @@ if (mode === "production") {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/apps/games/webpack.config.js
+++ b/apps/games/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
@@ -23,6 +23,7 @@ const jsxLoader = {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/apps/image-to-8bit/webpack.config.js
+++ b/apps/image-to-8bit/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const mode = process.env.NODE_ENV ?? "development";
 const minimize = mode === "production";
 const CopyWebpackPlugin = require("copy-webpack-plugin");
@@ -7,6 +7,7 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/apps/old-site/webpack.config.js
+++ b/apps/old-site/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 
@@ -59,6 +59,7 @@ const fontAwesomeLoader = {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/apps/preview/webpack.config.js
+++ b/apps/preview/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const mode = process.env.NODE_ENV ?? "development";
 const minimize = mode === "production";
 const CopyWebpackPlugin = require("copy-webpack-plugin");
@@ -7,6 +7,7 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/apps/settings/webpack.config.js
+++ b/apps/settings/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 
@@ -14,6 +14,7 @@ if (mode === "production") {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/apps/terminal/webpack.config.js
+++ b/apps/terminal/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const mode = process.env.NODE_ENV ?? "development";
 const minimize = mode === "production";
 const CopyWebpackPlugin = require("copy-webpack-plugin");
@@ -14,6 +14,7 @@ if (mode === "production") {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/apps/textpad/webpack.config.js
+++ b/apps/textpad/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const mode = process.env.NODE_ENV ?? "development";
 const minimize = mode === "production";
 const CopyWebpackPlugin = require("copy-webpack-plugin");
@@ -7,6 +7,7 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/apps/uptime-monitor/webpack.config.js
+++ b/apps/uptime-monitor/webpack.config.js
@@ -1,11 +1,12 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const mode = process.env.NODE_ENV ?? "development";
 const minimize = mode === "production";
 
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/backend/common/webpack.config.js
+++ b/backend/common/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule, NODE_TARGET } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, NODE_TARGET, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const mode = process.env.NODE_ENV ?? "development";
 const minimize = mode === "production";
 const plugins = [];
@@ -8,6 +8,7 @@ module.exports = {
 	mode,
 	target: "node",
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/backend/event-emitter/webpack.config.js
+++ b/backend/event-emitter/webpack.config.js
@@ -1,10 +1,11 @@
 const path = require("path");
-const { makeEsbuildRule, NODE_TARGET } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, NODE_TARGET, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const mode = process.env.NODE_ENV ?? "development";
 
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/backend/wireless-tools-provider/webpack.config.js
+++ b/backend/wireless-tools-provider/webpack.config.js
@@ -1,11 +1,12 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const mode = process.env.NODE_ENV ?? "development";
 const minimize = mode === "production";
 
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/development/cli/src/templates/application/webpack.config.js
+++ b/development/cli/src/templates/application/webpack.config.js
@@ -2,7 +2,7 @@ const path = require("path");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 
 const mode = process.env.NODE_ENV ?? "development";
 const production = mode === "production";
@@ -15,6 +15,7 @@ if (production) {
 module.exports = {
 	mode,
 	devtool: production ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/development/cli/src/templates/iframe-application/webpack.config.js
+++ b/development/cli/src/templates/iframe-application/webpack.config.js
@@ -2,11 +2,12 @@ const path = require("path");
 const mode = process.env.NODE_ENV ?? "development";
 const production = mode === "production";
 const CopyWebpackPlugin = require("copy-webpack-plugin");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 
 module.exports = {
 	mode,
 	devtool: production ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/development/webpack/index.js
+++ b/development/webpack/index.js
@@ -10,6 +10,18 @@
 const BROWSER_TARGET = ["chrome109", "edge147", "firefox150", "ios18.5", "opera127", "safari26.3"];
 const NODE_TARGET = "node22";
 
+// Quiet webpack's filesystem-cache chatter. PackFileCacheStrategy logs a
+// "Restoring/Caching failed for pack" warning whenever it meets a corrupt or
+// truncated .pack file (left behind by an interrupted or OOM-killed build).
+// webpack recovers on its own by rebuilding the entry, so the build is always
+// correct; the warnings are advisory noise, not actionable errors. Rush caches
+// each operation's terminal output, so a single corrupt-pack build gets its
+// warning log replayed on every later cache restore, which makes the noise look
+// permanent. Demoting infrastructure logging to "error" drops the advisory
+// cache warnings while leaving real compile errors and warnings (which come
+// through `stats`, not the infrastructure logger) fully visible.
+const INFRASTRUCTURE_LOGGING = { level: "error" };
+
 /**
  * Build the esbuild-loader `module.rules` entry used across meeseOS webpack configs.
  *
@@ -33,4 +45,4 @@ const makeEsbuildRule = (opts = {}) => {
 	};
 };
 
-module.exports = { makeEsbuildRule, BROWSER_TARGET, NODE_TARGET };
+module.exports = { makeEsbuildRule, BROWSER_TARGET, NODE_TARGET, INFRASTRUCTURE_LOGGING };

--- a/frontend/client/webpack.config.js
+++ b/frontend/client/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 
@@ -14,6 +14,7 @@ if (mode === "production") {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/frontend/cursor-effects/webpack.config.js
+++ b/frontend/cursor-effects/webpack.config.js
@@ -1,11 +1,12 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const mode = process.env.NODE_ENV ?? "development";
 const minimize = mode === "production";
 
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/frontend/dialogs/webpack.config.js
+++ b/frontend/dialogs/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 
@@ -14,6 +14,7 @@ if (mode === "production") {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/frontend/dynamic-wallpapers/webpack.config.js
+++ b/frontend/dynamic-wallpapers/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 
@@ -14,6 +14,7 @@ if (minimize) {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/frontend/gnome-icons/webpack.config.js
+++ b/frontend/gnome-icons/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 const IconThemePlugin = require("../../development/iconThemePlugin");
@@ -15,6 +15,7 @@ if (mode === "production") {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/frontend/google-api-provider/webpack.config.js
+++ b/frontend/google-api-provider/webpack.config.js
@@ -1,10 +1,11 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const mode = process.env.NODE_ENV ?? "development";
 
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/frontend/gui/webpack.config.js
+++ b/frontend/gui/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 
@@ -14,6 +14,7 @@ if (minimize) {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/frontend/panels/webpack.config.js
+++ b/frontend/panels/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 
@@ -14,6 +14,7 @@ if (mode === "production") {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/frontend/sounds/webpack.config.js
+++ b/frontend/sounds/webpack.config.js
@@ -4,6 +4,7 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 module.exports = {
 	devtool: "source-map",
 	mode: "production",
+	infrastructureLogging: { level: "error" },
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/frontend/standard-dark-theme/webpack.config.js
+++ b/frontend/standard-dark-theme/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 
@@ -14,6 +14,7 @@ if (mode === "production") {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/frontend/standard-theme/webpack.config.js
+++ b/frontend/standard-theme/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 
@@ -14,6 +14,7 @@ if (mode === "production") {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/frontend/static-wallpapers/webpack.config.js
+++ b/frontend/static-wallpapers/webpack.config.js
@@ -4,6 +4,7 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 module.exports = {
 	devtool: "source-map",
 	mode: "production",
+	infrastructureLogging: { level: "error" },
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/frontend/we10x-icons/webpack.config.js
+++ b/frontend/we10x-icons/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 const IconThemePlugin = require("../../development/iconThemePlugin");
@@ -15,6 +15,7 @@ if (mode === "production") {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/frontend/widgets/webpack.config.js
+++ b/frontend/widgets/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 
@@ -14,6 +14,7 @@ if (minimize) {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/frontend/windows8-theme/webpack.config.js
+++ b/frontend/windows8-theme/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { makeEsbuildRule } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 
@@ -14,6 +14,7 @@ if (mode === "production") {
 module.exports = {
 	mode,
 	devtool: mode === "production" ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -8,7 +8,7 @@ const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 const { EsbuildPlugin } = require("esbuild-loader");
-const { makeEsbuildRule, BROWSER_TARGET } = require("@meese-os/webpack-config");
+const { makeEsbuildRule, BROWSER_TARGET, INFRASTRUCTURE_LOGGING } = require("@meese-os/webpack-config");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
@@ -30,6 +30,7 @@ if (production) {
 module.exports = {
 	mode,
 	devtool: production ? "source-map" : "eval-cheap-module-source-map",
+	infrastructureLogging: INFRASTRUCTURE_LOGGING,
 	cache: {
 		type: "filesystem",
 		cacheDirectory: path.resolve(__dirname, ".webpack-cache"),


### PR DESCRIPTION
## Summary

`rush build` was spamming hundreds of `PackFileCacheStrategy: Restoring/Caching failed for pack ... Unexpected end of object` warnings.

**Root cause:** webpack's filesystem cache logs an advisory warning whenever it reads a corrupt or truncated `.pack` file (left behind by an interrupted or OOM-killed build). webpack recovers by rebuilding the entry, so the build is always correct (exit 0). The messages are noise, not errors. Because Rush caches each operation's terminal output, a single corrupt-pack build gets its warning log replayed on every later build-cache restore, making a one-time event look permanent.

**Fix:** demote webpack infrastructure logging to `error` across all package builds via a shared `INFRASTRUCTURE_LOGGING` constant in `@meese-os/webpack-config`. This drops the advisory cache chatter while leaving real compile errors and warnings (which flow through `stats`, not the infrastructure logger) fully visible. The two asset-only packages that do not consume the shared config inline the same `{ level: "error" }` literal.

## Test plan

- [x] Clean `rush build`: 36 packages, exit 0, 0 cache warnings, 0 compile errors.
- [x] Truncating a live `.pack` and rebuilding: 29 warnings before -> 0 after.
- [x] Injected module-not-found error still surfaces (`ERROR in ...`).
