### PR TITLE
feat(filemanager): context menu in empty list whitespace (#102)

### DIFF
--- a/apps/filemanager/index.js
+++ b/apps/filemanager/index.js
@@ -445,7 +445,7 @@ const createWindow = (core, proc) => {
 		.on("filemanager:menu:download", onMenuDownload)
 		.on("filemanager:menu:extract", onMenuExtract)
 		.on("filemanager:menu:compress", onMenuCompress)
-		.render(($content, win) => (wired = render($content, win)));
+		.render(($content, windowObj) => (wired = render($content, windowObj)));
 };
 
 /**
@@ -482,13 +482,13 @@ const createProcess = (core, args, options, metadata) => {
 	proc.on("meeseOS:filemanager:remote", onSettingsUpdate);
 	proc.on("filemanager:setting", onSetting);
 
-	const listener = (args) => {
-		if (args.pid === proc.pid) {
+	const listener = (eventArgs) => {
+		if (eventArgs.pid === proc.pid) {
 			return;
 		}
 
 		const currentPath = String(proc.args.path.path).replace(/\/$/, "");
-		const watchPath = String(args.path).replace(/\/$/, "");
+		const watchPath = String(eventArgs.path).replace(/\/$/, "");
 		if (currentPath === watchPath) {
 			win.emit("filemanager:refresh");
 		}

--- a/apps/filemanager/index.js
+++ b/apps/filemanager/index.js
@@ -142,6 +142,12 @@ const createView = (core, _proc, win) => {
 		(ev) => win.emit("filemanager:menu", { ev, name }, args);
 	const onInputEnter = (_ev, value) =>
 		win.emit("filemanager:navigate", { path: value });
+	const onBlankClick = (ev) => {
+		// Right-clicks on a file row have their own menu; ignore them here.
+		if (ev.target.closest(".meeseOS-gui-list-view-cell")) return;
+		ev.preventDefault();
+		win.emit("filemanager:blankcontextmenu", { ev });
+	};
 
 	const canGoBack = ({ list, index }) => !list.length || index <= 0;
 	const canGoForward = ({ list, index }) =>
@@ -187,7 +193,15 @@ const createView = (core, _proc, win) => {
 						onenter: onInputEnter,
 					}),
 				]),
-				h(Panes, { style: { flex: "1 1" } }, [h(MountView), h(FileView)]),
+				h(Panes, { style: { flex: "1 1" } }, [
+					h(MountView),
+					h(FileView, {
+						box: {
+							oncreate: (el) =>
+								el.addEventListener("contextmenu", onBlankClick),
+						},
+					}),
+				]),
 				h(Statusbar, {}, h("span", {}, state.status)),
 			]
 		);
@@ -359,6 +373,8 @@ const createWindow = (core, proc) => {
 		win.emit("filemanager:status", formatStatusMessage(files));
 	const onContextMenu = ({ ev, data }) =>
 		createMenu({ ev, name: "edit" }, data, true);
+	const onBlankContextMenu = ({ ev }) =>
+		createMenu({ ev, name: "directory" }, [], true);
 	const onReaddirRender = (args) => wired.setList(args);
 	const onRefresh = (...args) => vfs.refresh(...args);
 	const onOpen = (files) => {
@@ -407,6 +423,7 @@ const createWindow = (core, proc) => {
 		.on("filemanager:select", onSelectItem)
 		.on("filemanager:select", onSelectStatus)
 		.on("filemanager:contextmenu", onContextMenu)
+		.on("filemanager:blankcontextmenu", onBlankContextMenu)
 		.on("filemanager:readdir", onReaddirRender)
 		.on("filemanager:refresh", onRefresh)
 		.on("filemanager:open", onOpen)

--- a/apps/filemanager/src/factories.js
+++ b/apps/filemanager/src/factories.js
@@ -139,7 +139,7 @@ export const listViewRowFactory = (core, proc) => {
 			try {
 				const d = new Date(rawDate);
 				return `${dateformat(d, "yyyy-mm-dd")} ${dateformat(d, "HH:MM")}`;
-			} catch (e) {
+			} catch (_e) {
 				return rawDate;
 			}
 		}

--- a/apps/filemanager/src/factories.js
+++ b/apps/filemanager/src/factories.js
@@ -534,6 +534,31 @@ export const menuFactory = (core, proc, win) => {
 		{ label: "Quit", onclick: () => win.emit("filemanager:menu:quit") },
 	];
 
+	// Shown when right-clicking empty whitespace in the file listing.
+	const createDirectoryMenu = () => {
+		const menu = [
+			{ label: "Upload", onclick: () => win.emit("filemanager:menu:upload") },
+			{
+				label: "Create new directory",
+				onclick: () => win.emit("filemanager:menu:mkdir"),
+			},
+		];
+
+		if (clipboard.has(/^filemanager:/)) {
+			menu.push({
+				label: "Paste",
+				onclick: () => win.emit("filemanager:menu:paste"),
+			});
+		}
+
+		menu.push({
+			label: "Refresh",
+			onclick: () => win.emit("filemanager:menu:refresh"),
+		});
+
+		return menu;
+	};
+
 	const createEditMenu = async (items, isContextMenu) => {
 		const emitter = (name) => win.emit(name, items);
 		const item = items[items.length - 1];
@@ -728,6 +753,7 @@ export const menuFactory = (core, proc, win) => {
 
 	const menuItems = {
 		file: createFileMenu,
+		directory: createDirectoryMenu,
 		edit: createEditMenu,
 		view: createViewMenu,
 		go: createGoMenu,


### PR DESCRIPTION
> [!CAUTION]
> # 🤖 100% AI-Written Code, Human-Directed
> **Every line of code in this PR was generated by Claude (Anthropic). None of it was hand-typed by a human.**
>
> A human ([@ajmeese7](https://github.com/ajmeese7)) directed the work end to end: requirements, architecture and trade-off decisions, scope calls, and final verification sign-off. The typing was the robot; the judgment was human.
>
> Review it like any AI output: verify, don't assume.

---

## Summary

Closes #102. Right-clicking empty whitespace in the File Manager listing did nothing. It now opens a directory-level context menu so common actions are reachable without traveling to the menubar.

Menu items (shown on empty-area right-click):

- **Upload** (the issue's minimum ask)
- **Create new directory**
- **Paste** (only when the clipboard holds a `filemanager:*` entry)
- **Refresh**

Right-clicking an actual file/row keeps its existing per-file menu, unchanged.

## How it works

The `@meese-os/gui` `ListView` only fires `oncontextmenu` on individual row cells, so empty space below the rows was dead. This PR:

- Adds `createDirectoryMenu()` to `menuFactory` and registers it as `menuItems.directory` (`apps/filemanager/src/factories.js`).
- Adds `onBlankClick` in `createView`, which bails when the event target is inside a `.meeseOS-gui-list-view-cell` (so row clicks keep their own menu), otherwise `preventDefault()`s and emits `filemanager:blankcontextmenu`.
- Attaches that listener to the FileView root via `box.oncreate`. The gui `Element` only forwards `oncreate`/`ondestroy`, not arbitrary handlers, so a native `addEventListener("contextmenu", ...)` is used rather than an `oncontextmenu` prop.
- Wires `onBlankContextMenu` in `createWindow` to open the `directory` menu at the cursor.

`mkdir` and `paste` already rely on `state.currentPath` and the clipboard, so the empty-area menu needs no file selection. The mounts pane (`MountView`) is untouched.

## Test plan

- [x] `npx eslint index.js src/factories.js` in `apps/filemanager`: 0 errors (1 pre-existing, unrelated `no-unused-vars` warning in `formattedDate`).
- [x] Manual: right-click empty space below the file list → menu appears at the cursor with Upload / Create new directory / Refresh (+ Paste when something is copied/cut).
- [x] Manual: right-click a file/row → existing per-file menu still appears, unchanged.
- [x] Manual: right-click empty space, Upload → file picker opens and upload completes into the current directory.

Files changed: `apps/filemanager/index.js`, `apps/filemanager/src/factories.js`.
