### PR TITLE
feat(client): standard-icon fallback for app icons (#110)

### DIFF
--- a/frontend/client/__tests__/application.js
+++ b/frontend/client/__tests__/application.js
@@ -43,6 +43,26 @@ describe("Application", () => {
 		expect(application.resource("foo")).toBe("/apps/Jest/foo");
 	});
 
+	test("#icon - packaged file resolves via resource()", () => {
+		expect(application.icon("icon.png")).toBe(application.resource("icon.png"));
+		expect(application.icon("assets/logo.svg")).toBe(
+			application.resource("assets/logo.svg")
+		);
+	});
+
+	test("#icon - bare name resolves via the icon theme", () => {
+		const themeIcon = core.make("meeseOS/theme").icon("utilities-terminal");
+		expect(application.icon("utilities-terminal")).toBe(themeIcon);
+		// A themed icon must not be the same as a packaged resource path.
+		expect(application.icon("utilities-terminal")).not.toBe(
+			application.resource("utilities-terminal")
+		);
+	});
+
+	test("#icon - returns null when no icon is set", () => {
+		expect(application.icon()).toBeNull();
+	});
+
 	test("#createWindow", () => {
 		const fn = jest.fn(() => {});
 

--- a/frontend/client/index.d.ts
+++ b/frontend/client/index.d.ts
@@ -942,6 +942,14 @@ declare class Application extends EventEmitter {
 	resource(path?: string, options?: object): string;
 
 	/**
+	 * Resolves this application's icon to a URI.
+	 * A bare name (no extension/path) is resolved through the active icon theme;
+	 * anything else is treated as a file packaged with the application.
+	 * Defaults to the metadata icon and returns null when no icon is set.
+	 */
+	icon(name?: string): string | null;
+
+	/**
 	 * Performs a request to the MeeseOS server with the application
 	 * as the endpoint.
 	 */

--- a/frontend/client/src/application.js
+++ b/frontend/client/src/application.js
@@ -259,6 +259,29 @@ export default class Application extends EventEmitter {
 	}
 
 	/**
+	 * Resolves this application's icon to a URI.
+	 *
+	 * A bare name (no extension and no path separator, e.g. "folder" or
+	 * "utilities-terminal") is treated as a standard icon and resolved through
+	 * the active icon theme, so it honours the user's icon style preference.
+	 * Anything else (e.g. "icon.png" or "assets/logo.svg") is treated as a file
+	 * packaged with the application.
+	 *
+	 * @param {String} [name] Icon to resolve; defaults to the metadata icon
+	 * @returns {String|null} A complete URI, or null when no icon is set
+	 */
+	icon(name = this.metadata.icon) {
+		if (!name) {
+			return null;
+		}
+
+		const isStandardIcon = !/[/.]/.test(name);
+		return isStandardIcon
+			? this.core.make("meeseOS/theme").icon(name)
+			: this.resource(name);
+	}
+
+	/**
 	 * Performs a request to the MeeseOS server with the application
 	 * as the endpoint.
 	 * @param {String} [path="/"] Append this to endpoint
@@ -344,7 +367,18 @@ export default class Application extends EventEmitter {
 			this.metadata.name,
 			options.id
 		);
-		const instance = new Window(this.core, merge(options, applyOptions));
+		const windowOptions = merge(options, applyOptions);
+
+		// Fall back to the application's (optionally theme-resolved) icon when a
+		// window does not specify one of its own, so apps need not hard-code it.
+		if (!windowOptions.icon) {
+			const appIcon = this.icon();
+			if (appIcon) {
+				windowOptions.icon = appIcon;
+			}
+		}
+
+		const instance = new Window(this.core, windowOptions);
 
 		if (this.options.restore) {
 			const windows = this.options.restore.windows || [];

--- a/frontend/client/src/application.js
+++ b/frontend/client/src/application.js
@@ -382,10 +382,10 @@ export default class Application extends EventEmitter {
 
 		if (this.options.restore) {
 			const windows = this.options.restore.windows || [];
-			const found = windows.findIndex((win) => win.id === instance.id);
+			const restoreIndex = windows.findIndex((win) => win.id === instance.id);
 
-			if (found !== -1) {
-				const restore = windows[found];
+			if (restoreIndex !== -1) {
+				const restore = windows[restoreIndex];
 				instance.setPosition(restore.position, true);
 				instance.setDimension(restore.dimension);
 
@@ -395,7 +395,7 @@ export default class Application extends EventEmitter {
 					instance.maximize();
 				}
 
-				this.options.restore.windows.splice(found, 1);
+				this.options.restore.windows.splice(restoreIndex, 1);
 			}
 		}
 


### PR DESCRIPTION
> [!CAUTION]
> # 🤖 100% AI-Written Code, Human-Directed
> **Every line of code in this PR was generated by Claude (Anthropic). None of it was hand-typed by a human.**
>
> A human ([@ajmeese7](https://github.com/ajmeese7)) directed the work end to end: requirements, architecture and trade-off decisions, scope calls, and final verification sign-off. The typing was the robot; the judgment was human.
>
> Review it like any AI output: verify, don't assume.

---

## Summary

Closes #110. Apps currently have to package an image and hard-code it as their icon (`metadata.icon` = `"icon.png"`), forcing them to pass it to every window. This adds a fallback so an app's icon can instead be a **standard icon name resolved through the active icon theme**, letting apps conform to the user's icon-style preference instead of being hard-coded.

## How it works

New `Application.icon()` method:

```js
icon(name = this.metadata.icon) {
  if (!name) return null;
  const isStandardIcon = !/[/.]/.test(name);
  return isStandardIcon
    ? this.core.make("meeseOS/theme").icon(name)
    : this.resource(name);
}
```

- **Bare name** (no `.`, no `/`) → e.g. `folder`, `utilities-terminal` → resolved via the icon theme (`meeseOS/theme` `icon()`), so it follows the user's icon pack.
- **Anything else** → e.g. `icon.png`, `assets/logo.svg`, a full URL → treated as a file packaged with the app (`resource()`), exactly as today.

`createWindow()` now defaults the window icon to `this.icon()` when a window doesn't supply its own. Previously, omitting `icon` fell through to a generic static `defaultIcon`; now it correctly uses the app's metadata icon.

Standard freedesktop icon names use hyphens, not dots, so the `.`-means-packaged heuristic is unambiguous in practice.

## Backward compatibility

- Apps that pass an explicit window `icon` (all current apps) are **unchanged**.
- Apps that omitted `icon` now show their metadata icon instead of the generic default, which is strictly more correct.
- No app package was modified, so this doesn't conflict with other in-flight PRs.

## Test plan

- [x] `npx eslint src/application.js` in `frontend/client`: 0 problems.
- [x] `npx jest __tests__/application.js`: 17 passed (3 new):
  - packaged file (`icon.png`, `assets/logo.svg`) resolves identically to `resource()`
  - bare name resolves identically to the theme `icon()` and differs from the packaged path
  - returns `null` when no icon is set

Files changed: `frontend/client/src/application.js`, `frontend/client/index.d.ts`, `frontend/client/__tests__/application.js`.
