### PR TITLE
fix(widgets): analog clock centered after non-square resize (#152)

### DIFF
--- a/frontend/widgets/src/items/analogclock.js
+++ b/frontend/widgets/src/items/analogclock.js
@@ -86,39 +86,21 @@ export default class AnalogClockWidget extends Widget {
 				},
 			}
 		);
-
-		this.$tmpCanvas = document.createElement("canvas");
-		this.$tmpCanvas.width = startingSize;
-		this.$tmpCanvas.height = startingSize;
-		this.tmpContext = this.$tmpCanvas.getContext("2d");
-
-		/**
-		 * Indicates whether the clock has already been rendered at
-		 * the specified size.
-		 * @type {Boolean}
-		 */
-		this.firstRender = true;
 	}
 
-	compute() {
+	render({ context }) {
+		// Always work from the canvas's current pixel size. The base render loop
+		// captures the starting dimensions once, so reading them here keeps the
+		// clock centered and circular after the widget is resized to any aspect
+		// ratio (fixes off-center numbers on tall/wide widgets).
 		const { width, height } = this.$canvas;
-		const { $tmpCanvas } = this;
 
-		$tmpCanvas.width = width;
-		$tmpCanvas.height = height;
-	}
-
-	onResize() {
-		this.compute();
-		this.firstRender = true;
-	}
-
-	render({ context, width, height }) {
-		// Translate to center of canvas initially
-		if (this.firstRender) {
-			context.translate(width / 2, height / 2);
-			this.firstRender = false;
-		}
+		// Reset the transform every frame and clear, rather than translating once
+		// and relying on the matrix persisting (it is reset whenever the canvas
+		// is resized, which is exactly when the old approach broke).
+		context.setTransform(1, 0, 0, 1, 0, 0);
+		context.clearRect(0, 0, width, height);
+		context.translate(width / 2, height / 2);
 
 		const size = Math.min(width, height);
 		const radius = (size / 2) * 0.9;
@@ -149,7 +131,6 @@ export default class AnalogClockWidget extends Widget {
 			(btn, value) => {
 				if (btn === "ok") {
 					this.options.fontFamily = value.name;
-					this.compute();
 					this.saveSettings();
 				}
 			}
@@ -170,7 +151,6 @@ export default class AnalogClockWidget extends Widget {
 			(btn, value) => {
 				if (btn === "ok") {
 					this.options.colors = value;
-					this.compute();
 					this.saveSettings();
 				}
 			}


### PR DESCRIPTION
> [!CAUTION]
> # 🤖 100% AI-Written Code, Human-Directed
> **Every line of code in this PR was generated by Claude (Anthropic). None of it was hand-typed by a human.**
>
> A human ([@ajmeese7](https://github.com/ajmeese7)) directed the work end to end: requirements, architecture and trade-off decisions, scope calls, and final verification sign-off. The typing was the robot; the judgment was human.
>
> Review it like any AI output: verify, don't assume.

---

## Summary

Closes #152. When the analog clock widget was resized to a non-square shape, the numbers and hands were placed strangely (see the screenshots in the issue). This fixes the rendering so the clock stays centered and circular at any aspect ratio.

## Root cause

Two compounding bugs:

1. The base `Widget.start()` captures `width`/`height` from `options.dimension` **once** into the render closure, so `render()` keeps receiving the *starting* dimensions even after the widget is resized.
2. The clock translated to the center only on `firstRender` and then relied on the canvas transform persisting between frames. Resizing the canvas resets that transform, and the re-translate used the **stale** dimensions, so the drawing origin landed off-center on tall/wide widgets.

The `$tmpCanvas` / `tmpContext` / `compute()` members were vestigial: the temp context was created and resized but never drawn from.

## Fix

`render()` now reads the canvas's **current** pixel size every frame, resets the transform, clears, and re-centers:

```js
render({ context }) {
  const { width, height } = this.$canvas;
  context.setTransform(1, 0, 0, 1, 0, 0);
  context.clearRect(0, 0, width, height);
  context.translate(width / 2, height / 2);
  const size = Math.min(width, height);
  const radius = (size / 2) * 0.9;
  this.drawClock(context, radius);
}
```

`radius` keys off `Math.min(width, height)`, so the face stays circular regardless of aspect ratio. The fragile `firstRender` model, the `onResize`/`compute` overrides, and the unused temp-canvas members are removed (no behavior depended on them).

Scope note: this is a localized fix in the analog clock. The base-class staleness (problem #1) is sidestepped by reading `this.$canvas` directly, so no shared `Widget` code is touched and other widgets are unaffected.

## Test plan

- [x] `npx eslint src/items/analogclock.js`: 0 problems.
- [x] No remaining references to the removed members (`firstRender`, `tmpCanvas`, `tmpContext`, `compute`).
- [x] Manual: add the Analog Clock widget, resize it tall, then wide. Clock stays centered and circular; numbers land on the dial; hands point correctly. (The widgets package has no jest harness; canvas rendering needs a real browser, so this step is visual.)

Files changed: `frontend/widgets/src/items/analogclock.js`.
