### PR TITLE
feat(panels): calendar popover for the clock panel item (#126)

### DIFF
--- a/frontend/panels/src/items/_clock.scss
+++ b/frontend/panels/src/items/_clock.scss
@@ -32,4 +32,77 @@
 	display: flex;
 	align-items: center;
 	white-space: nowrap;
+	position: relative;
+
+	.meeseOS-clock-time {
+		cursor: pointer;
+	}
+
+	.meeseOS-clock-popover {
+		position: absolute;
+		right: 0;
+		z-index: 100;
+		min-width: 15em;
+		padding: 0.5em;
+		background: #fff;
+		color: #000;
+		border: 1px solid rgb(0 0 0 / 20%);
+		border-radius: 4px;
+		box-shadow: 0 2px 8px rgb(0 0 0 / 30%);
+		font-size: 0.85rem;
+		cursor: default;
+	}
+
+	.meeseOS-clock-popover-date {
+		margin-bottom: 0.5em;
+		font-weight: bold;
+		text-align: center;
+	}
+
+	.meeseOS-clock-popover-nav {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 0.25em;
+
+		button {
+			padding: 0 0.5em;
+			border: 0;
+			background: transparent;
+			color: inherit;
+			font-size: 1em;
+			cursor: pointer;
+		}
+	}
+
+	.meeseOS-clock-popover-grid {
+		display: grid;
+		grid-template-columns: repeat(7, 1fr);
+		gap: 2px;
+		text-align: center;
+	}
+
+	.meeseOS-clock-popover-weekday {
+		font-weight: bold;
+		opacity: 0.7;
+	}
+
+	.meeseOS-clock-popover-day {
+		padding: 0.2em 0;
+
+		&.meeseOS__active {
+			border-radius: 50%;
+			background: #2196f3;
+			color: #fff;
+		}
+	}
+}
+
+// Open the calendar below the clock on a top panel, above it on a bottom panel.
+.meeseOS-panel[data-position="top"] .meeseOS-clock-popover {
+	top: 100%;
+}
+
+.meeseOS-panel[data-position="bottom"] .meeseOS-clock-popover {
+	bottom: 100%;
 }

--- a/frontend/panels/src/items/clock.js
+++ b/frontend/panels/src/items/clock.js
@@ -64,6 +64,48 @@ const buildMonthCells = (year, month) => {
 };
 
 /**
+ * Renders the calendar popover for the currently viewed month.
+ * @param {Object} state Item state
+ * @param {Object} actions Bound actions
+ * @returns {Node} A *virtual* node
+ */
+const renderPopover = (state, actions) => {
+	const today = new Date();
+	const { year, month } = state.view;
+	const showingThisMonth =
+		year === today.getFullYear() && month === today.getMonth();
+
+	const weekdays = WEEKDAYS.map((label) =>
+		h("span", { class: "meeseOS-clock-popover-weekday" }, label)
+	);
+
+	const days = buildMonthCells(year, month).map((day) => {
+		const isToday = showingThisMonth && day === today.getDate();
+		return h(
+			"span",
+			{
+				class: `meeseOS-clock-popover-day${isToday ? " meeseOS__active" : ""}`,
+			},
+			day ? String(day) : ""
+		);
+	});
+
+	return h("div", { class: "meeseOS-clock-popover" }, [
+		h(
+			"div",
+			{ class: "meeseOS-clock-popover-date" },
+			dateformat(today, "dddd, mmmm d, yyyy")
+		),
+		h("div", { class: "meeseOS-clock-popover-nav" }, [
+			h("button", { type: "button", onclick: () => actions.prevMonth() }, "‹"),
+			h("span", {}, dateformat(new Date(year, month, 1), "mmmm yyyy")),
+			h("button", { type: "button", onclick: () => actions.nextMonth() }, "›"),
+		]),
+		h("div", { class: "meeseOS-clock-popover-grid" }, [...weekdays, ...days]),
+	]);
+};
+
+/**
  * Clock.
  *
  * @desc Clock Panel Item. Shows the time, and opens a calendar popover with the
@@ -111,57 +153,6 @@ export default class ClockPanelItem extends PanelItem {
 		super.destroy();
 	}
 
-	/**
-	 * Renders the calendar popover for the currently viewed month.
-	 * @param {Object} state Item state
-	 * @param {Object} actions Bound actions
-	 * @returns {Node} A *virtual* node
-	 */
-	renderPopover(state, actions) {
-		const today = new Date();
-		const { year, month } = state.view;
-		const showingThisMonth =
-			year === today.getFullYear() && month === today.getMonth();
-
-		const weekdays = WEEKDAYS.map((label) =>
-			h("span", { class: "meeseOS-clock-popover-weekday" }, label)
-		);
-
-		const days = buildMonthCells(year, month).map((day) => {
-			const isToday = showingThisMonth && day === today.getDate();
-			return h(
-				"span",
-				{
-					class:
-						"meeseOS-clock-popover-day" + (isToday ? " meeseOS__active" : ""),
-				},
-				day ? String(day) : ""
-			);
-		});
-
-		return h("div", { class: "meeseOS-clock-popover" }, [
-			h(
-				"div",
-				{ class: "meeseOS-clock-popover-date" },
-				dateformat(today, "dddd, mmmm d, yyyy")
-			),
-			h("div", { class: "meeseOS-clock-popover-nav" }, [
-				h(
-					"button",
-					{ type: "button", onclick: () => actions.prevMonth() },
-					"‹"
-				),
-				h("span", {}, dateformat(new Date(year, month, 1), "mmmm yyyy")),
-				h(
-					"button",
-					{ type: "button", onclick: () => actions.nextMonth() },
-					"›"
-				),
-			]),
-			h("div", { class: "meeseOS-clock-popover-grid" }, [...weekdays, ...days]),
-		]);
-	}
-
 	render(state, actions) {
 		const children = [
 			h(
@@ -176,7 +167,7 @@ export default class ClockPanelItem extends PanelItem {
 		];
 
 		if (state.open) {
-			children.push(this.renderPopover(state, actions));
+			children.push(renderPopover(state, actions));
 		}
 
 		return super.render("clock", children);

--- a/frontend/panels/src/items/clock.js
+++ b/frontend/panels/src/items/clock.js
@@ -32,38 +32,153 @@ import { h } from "hyperapp";
 import PanelItem from "../panel-item";
 import dateformat from "dateformat";
 
+const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+
+/** Current time string shown in the panel. */
+const currentTime = () => dateformat(new Date(), "HH:MM:ss");
+
+/** The year/month pair currently displayed by the calendar. */
+const monthView = (date) => ({ year: date.getFullYear(), month: date.getMonth() });
+
+/** Shifts a {year, month} view by a number of months. */
+const shiftMonth = ({ year, month }, delta) =>
+	monthView(new Date(year, month + delta, 1));
+
+/**
+ * Builds the calendar cells for a month: leading blanks for the offset of the
+ * first day, then the day numbers.
+ * @param {Number} year Full year
+ * @param {Number} month Zero-based month
+ * @returns {Array<Number|null>} Cells (null = blank pad)
+ */
+const buildMonthCells = (year, month) => {
+	const leadingBlanks = new Date(year, month, 1).getDay();
+	const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+	const cells = Array.from({ length: leadingBlanks }, () => null);
+	for (let day = 1; day <= daysInMonth; day++) {
+		cells.push(day);
+	}
+
+	return cells;
+};
+
 /**
  * Clock.
  *
- * @desc Clock Panel Item
+ * @desc Clock Panel Item. Shows the time, and opens a calendar popover with the
+ * full date on click (the time also exposes the full date as a hover tooltip).
  */
 export default class ClockPanelItem extends PanelItem {
 	init() {
-		const date = () => dateformat(new Date(), "HH:MM:ss");
 		if (this.inited) return;
 
 		const actions = super.init(
 			{
-				time: date(),
+				time: currentTime(),
+				open: false,
+				view: monthView(new Date()),
 			},
 			{
-				increment: () => (_state) => {
-					return { time: date() };
-				},
+				increment: () => () => ({ time: currentTime() }),
+				toggle: () => (state) =>
+					state.open
+						? { open: false }
+						: { open: true, view: monthView(new Date()) },
+				close: () => () => ({ open: false }),
+				prevMonth: () => (state) => ({ view: shiftMonth(state.view, -1) }),
+				nextMonth: () => (state) => ({ view: shiftMonth(state.view, 1) }),
 			}
 		);
 
-		this.interval = setInterval(() => {
-			actions.increment();
-		}, 1000);
+		this.interval = setInterval(() => actions.increment(), 1000);
+
+		// Close the calendar when clicking anywhere outside the clock item.
+		this.onDocumentClick = (ev) => {
+			if (!ev.target.closest(".meeseOS-panel-item[data-name=clock]")) {
+				actions.close();
+			}
+		};
+		document.addEventListener("click", this.onDocumentClick);
 	}
 
 	destroy() {
 		this.interval = clearInterval(this.interval);
+		if (this.onDocumentClick) {
+			document.removeEventListener("click", this.onDocumentClick);
+			this.onDocumentClick = null;
+		}
 		super.destroy();
 	}
 
-	render(state, _actions) {
-		return super.render("clock", [h("span", {}, state.time)]);
+	/**
+	 * Renders the calendar popover for the currently viewed month.
+	 * @param {Object} state Item state
+	 * @param {Object} actions Bound actions
+	 * @returns {Node} A *virtual* node
+	 */
+	renderPopover(state, actions) {
+		const today = new Date();
+		const { year, month } = state.view;
+		const showingThisMonth =
+			year === today.getFullYear() && month === today.getMonth();
+
+		const weekdays = WEEKDAYS.map((label) =>
+			h("span", { class: "meeseOS-clock-popover-weekday" }, label)
+		);
+
+		const days = buildMonthCells(year, month).map((day) => {
+			const isToday = showingThisMonth && day === today.getDate();
+			return h(
+				"span",
+				{
+					class:
+						"meeseOS-clock-popover-day" + (isToday ? " meeseOS__active" : ""),
+				},
+				day ? String(day) : ""
+			);
+		});
+
+		return h("div", { class: "meeseOS-clock-popover" }, [
+			h(
+				"div",
+				{ class: "meeseOS-clock-popover-date" },
+				dateformat(today, "dddd, mmmm d, yyyy")
+			),
+			h("div", { class: "meeseOS-clock-popover-nav" }, [
+				h(
+					"button",
+					{ type: "button", onclick: () => actions.prevMonth() },
+					"‹"
+				),
+				h("span", {}, dateformat(new Date(year, month, 1), "mmmm yyyy")),
+				h(
+					"button",
+					{ type: "button", onclick: () => actions.nextMonth() },
+					"›"
+				),
+			]),
+			h("div", { class: "meeseOS-clock-popover-grid" }, [...weekdays, ...days]),
+		]);
+	}
+
+	render(state, actions) {
+		const children = [
+			h(
+				"span",
+				{
+					class: "meeseOS-clock-time",
+					title: dateformat(new Date(), "dddd, mmmm d, yyyy"),
+					onclick: () => actions.toggle(),
+				},
+				state.time
+			),
+		];
+
+		if (state.open) {
+			children.push(this.renderPopover(state, actions));
+		}
+
+		return super.render("clock", children);
 	}
 }


### PR DESCRIPTION
> [!CAUTION]
> # 🤖 100% AI-Written Code, Human-Directed
> **Every line of code in this PR was generated by Claude (Anthropic). None of it was hand-typed by a human.**
>
> A human ([@ajmeese7](https://github.com/ajmeese7)) directed the work end to end: requirements, architecture and trade-off decisions, scope calls, and final verification sign-off. The typing was the robot; the judgment was human.
>
> Review it like any AI output: verify, don't assume.

---

## Summary

Closes #126. The clock panel item showed only `HH:MM:ss`. This gives it parity with desktop OS clocks:

- **Hover** the time → native `title` tooltip with the full date (e.g. "Tuesday, June 17, 2026").
- **Click** the time → a calendar popover with the full date, month navigation (‹ / ›), weekday headers, and the day grid with **today highlighted**.
- Clicking anywhere outside the clock closes the popover.

## How it works

- `clock.js` gains `open` / `view` state and `toggle` / `close` / `prevMonth` / `nextMonth` actions. A pure helper `buildMonthCells(year, month)` produces the leading blanks + day numbers; `renderPopover` draws the header, nav, and CSS-grid day layout.
- An outside-click listener is added in `init()` and removed in `destroy()`; it closes the popover unless the click is within the clock item (`closest(".meeseOS-panel-item[data-name=clock]")`).
- Positioning is pure CSS off the panel's existing `data-position` attribute: `top: 100%` for a top panel, `bottom: 100%` for a bottom panel. No layout measurement needed.

## Test plan

- [x] `npx eslint src/items/clock.js`: 0 problems.
- [x] `npx stylelint src/items/_clock.scss`: 0 problems.
- [x] Calendar math sanity-checked: June 2026 → 1 leading blank + 30 days; Feb 2024 (leap) → 4 leading blanks + 29 days.
- [x] Manual: click the clock to open/close; verify today is highlighted, prev/next change the month, the tooltip shows the full date, and clicking elsewhere closes it. (Panels has no jest harness, so this step is visual.)

Files changed: `frontend/panels/src/items/clock.js`, `frontend/panels/src/items/_clock.scss`.
