### PR TITLE
feat(preview): zoom-to-fit and zoom slider (#154)

### DIFF
--- a/apps/preview/index.js
+++ b/apps/preview/index.js
@@ -145,14 +145,14 @@ const view = (core, proc, win, refs) => (state, actions) =>
 		].filter((i) => Boolean(i))
 	);
 
-const openFile = async (core, proc, win, a, file, restore) => {
+const openFile = async (core, proc, win, actions, file, restore) => {
 	const url = await core.make("meeseOS/vfs").url(file);
 	const ref = { ...file, url };
 
 	if (/^image/.test(file.mime)) {
-		a.setImage({ image: ref, restore });
+		actions.setImage({ image: ref, restore });
 	} else if (/^video/.test(file.mime)) {
-		a.setVideo({ video: ref, restore });
+		actions.setVideo({ video: ref, restore });
 	}
 
 	win.setTitle(`${proc.metadata.title} - ${file.filename}`);
@@ -174,7 +174,7 @@ meeseOS.register(applicationName, (core, args, options, metadata) => {
 	});
 
 	win.on("destroy", () => proc.destroy());
-	win.on("render", (win) => win.focus());
+	win.on("render", () => win.focus());
 	win.on("drop", (ev, data) => {
 		if (data.isFile && data.mime) {
 			const found = metadata.mimes.find((m) => new RegExp(m).test(data.mime));
@@ -185,9 +185,9 @@ meeseOS.register(applicationName, (core, args, options, metadata) => {
 	});
 
 	// TODO: Decompose this
-	win.render(($content, win) => {
+	win.render(($content) => {
 		const refs = { container: null };
-		const a = app(
+		const actions = app(
 			{
 				image: null,
 				video: null,
@@ -266,7 +266,7 @@ meeseOS.register(applicationName, (core, args, options, metadata) => {
 		);
 
 		proc.on("readFile", (file, restore) =>
-			openFile(core, proc, win, a, file, restore)
+			openFile(core, proc, win, actions, file, restore)
 		);
 
 		if (args.file) {

--- a/apps/preview/index.js
+++ b/apps/preview/index.js
@@ -34,46 +34,116 @@ import {
 	Image,
 	Menubar,
 	MenubarItem,
+	RangeField,
 	Video,
 } from "@meese-os/gui";
 import { app, h } from "hyperapp";
 import { name as applicationName } from "./metadata.json";
 import meeseOS from "meeseOS";
 
-const view = (core, proc, win) => (state, actions) =>
-	h(Box, {}, [
-		h(Menubar, {}, [
-			h(
-				MenubarItem,
-				{
-					onclick: (ev) => actions.menu(ev),
-				},
-				"File"
-			),
-		]),
-		h(
-			BoxContainer,
-			{
-				grow: 1,
-				shrink: 1,
-				style: { overflow: state.image ? "auto" : "hidden" },
+/** Smallest and largest zoom the slider allows, as a percentage. */
+const MIN_ZOOM = 10;
+const MAX_ZOOM = 400;
+
+/**
+ * Computes the zoom percentage that fits the image within its container,
+ * never upscaling past natural size.
+ * @param {{width: Number, height: Number}} naturalSize Image natural size
+ * @param {Element} container The scroll container element
+ * @returns {Number} Zoom percentage
+ */
+const computeFitZoom = (naturalSize, container) => {
+	if (!naturalSize || !container) return 100;
+
+	const fit = Math.min(
+		container.clientWidth / naturalSize.width,
+		container.clientHeight / naturalSize.height,
+		1
+	);
+
+	return Math.max(MIN_ZOOM, Math.round(fit * 100));
+};
+
+/** The displayed image width in pixels for the current zoom, or undefined pre-load. */
+const imageWidth = (state) =>
+	state.naturalSize
+		? Math.round((state.naturalSize.width * state.zoom) / 100)
+		: undefined;
+
+/** Toolbar with a Fit button, a zoom slider, and the current percentage. */
+const zoomBar = (state, actions) =>
+	h(
+		"div",
+		{
+			class: "meeseOS-gui",
+			style: {
+				display: "flex",
+				alignItems: "center",
+				gap: "0.5em",
+				padding: "0.25em 0.5em",
 			},
-			[
-				state.image
-					? h(Image, {
-						src: state.image.url,
-						onload: (ev) => actions.resizeFit(ev.target),
-					  })
-					: null,
-				state.video
-					? h(Video, {
-						src: state.video.url,
-						onload: (ev) => actions.resizeFit(ev.target),
-					  })
-					: null,
-			].filter((i) => Boolean(i))
-		),
-	]);
+		},
+		[
+			h("button", { type: "button", onclick: () => actions.fitImage() }, "Fit"),
+			h(RangeField, {
+				min: String(MIN_ZOOM),
+				max: String(MAX_ZOOM),
+				value: String(state.zoom),
+				style: { width: "100%" },
+				box: { grow: 1, shrink: 1 },
+				oninput: (_ev, value) => actions.setZoom(Number(value)),
+			}),
+			h(
+				"span",
+				{ style: { minWidth: "3em", textAlign: "right" } },
+				`${state.zoom}%`
+			),
+		]
+	);
+
+const view = (core, proc, win, refs) => (state, actions) =>
+	h(
+		Box,
+		{},
+		[
+			h(Menubar, {}, [
+				h(
+					MenubarItem,
+					{
+						onclick: (ev) => actions.menu(ev),
+					},
+					"File"
+				),
+			]),
+			state.image ? zoomBar(state, actions) : null,
+			h(
+				BoxContainer,
+				{
+					grow: 1,
+					shrink: 1,
+					style: { overflow: state.image || state.video ? "auto" : "hidden" },
+				},
+				[
+					state.image
+						? h(Image, {
+							src: state.image.url,
+							width: imageWidth(state),
+							oncreate: (el) => {
+								refs.container = el.parentNode?.parentNode;
+							},
+							onload: (ev) => actions.imageLoaded(ev.target),
+						  })
+						: null,
+					state.video
+						? h(Video, {
+							src: state.video.url,
+							onload: (ev) => actions.resizeFit(ev.target),
+						  })
+						: null,
+				].filter((i) => Boolean(i))
+			),
+		].filter((i) => Boolean(i))
+	);
 
 const openFile = async (core, proc, win, a, file, restore) => {
 	const url = await core.make("meeseOS/vfs").url(file);
@@ -116,11 +186,14 @@ meeseOS.register(applicationName, (core, args, options, metadata) => {
 
 	// TODO: Decompose this
 	win.render(($content, win) => {
+		const refs = { container: null };
 		const a = app(
 			{
 				image: null,
 				video: null,
 				restore: false,
+				zoom: 100,
+				naturalSize: null,
 			},
 			{
 				resizeFit: (target) => (state) => {
@@ -133,8 +206,37 @@ meeseOS.register(applicationName, (core, args, options, metadata) => {
 					}
 				},
 
-				setVideo: ({ video, restore }) => ({ video, restore }),
-				setImage: ({ image, restore }) => ({ image, restore }),
+				imageLoaded: (target) => (state) => {
+					const naturalSize = {
+						width: target.naturalWidth,
+						height: target.naturalHeight,
+					};
+
+					// Default to fitting the image in the window; honor a restored zoom.
+					if (state.restore) return { naturalSize };
+
+					return {
+						naturalSize,
+						zoom: computeFitZoom(naturalSize, target.parentNode?.parentNode),
+					};
+				},
+
+				setZoom: (zoom) => () => ({
+					zoom: Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, Math.round(zoom))),
+				}),
+
+				fitImage: () => (state) => ({
+					zoom: computeFitZoom(state.naturalSize, refs.container),
+				}),
+
+				setVideo: ({ video, restore }) => ({ video, image: null, restore }),
+				setImage: ({ image, restore }) => ({
+					image,
+					video: null,
+					restore,
+					zoom: 100,
+					naturalSize: null,
+				}),
 				menu: (ev) => {
 					core.make("meeseOS/contextmenu").show({
 						menu: [
@@ -159,7 +261,7 @@ meeseOS.register(applicationName, (core, args, options, metadata) => {
 					});
 				},
 			},
-			view(core, proc, win),
+			view(core, proc, win, refs),
 			$content
 		);
 


### PR DESCRIPTION
> [!CAUTION]
> # 🤖 100% AI-Written Code, Human-Directed
> **Every line of code in this PR was generated by Claude (Anthropic). None of it was hand-typed by a human.**
>
> A human ([@ajmeese7](https://github.com/ajmeese7)) directed the work end to end: requirements, architecture and trade-off decisions, scope calls, and final verification sign-off. The typing was the robot; the judgment was human.
>
> Review it like any AI output: verify, don't assume.

---

## Summary

Closes #154. The Preview app opened images at natural size and grew the window to match, so a large image had to be scrolled. It now:

- **Fits the whole image into the window on open** (scaled down to fit, never upscaled past 100%).
- Adds a **zoom toolbar**: a Fit button, a zoom slider (10–400%), and a live percentage readout.

Video keeps its previous resize-to-fit-the-window behavior.

## How it works

- The image's old `onload` called `win.resizeFit(target)` (grow window to natural size). For images that's replaced by `imageLoaded`, which captures the natural size and computes the fit-to-container zoom (`computeFitZoom`).
- Image width is driven by a numeric `zoom` percentage (`imageWidth(state)` → pixel width); the scroll container has `overflow: auto`, so zooming past fit scrolls.
- The Fit button recomputes fit from the **live** container (captured via `oncreate`), so it stays correct after the window is resized.
- `setImage`/`setVideo` now clear the other medium and reset zoom.

## Test plan

- [x] `npx eslint index.js` in `apps/preview`: 0 problems.
- [x] Fit math sanity-checked: 800×600 in a 400px box → 50%; small image → 100% (no upscale); tall image → height-bound; null guards → 100%.
- [x] Manual: open a large image → whole image visible, no scroll. Drag the slider up → image grows and the container scrolls. Click **Fit** → back to fit. Open a different image → zoom resets and refits. (Preview has no jest harness, so this step is visual.)

Files changed: `apps/preview/index.js`.
