### PR TITLE
fix(build): make @meese-os/event-emitter UMD bundle browser-safe

### DIFF
--- a/backend/event-emitter/webpack.config.js
+++ b/backend/event-emitter/webpack.config.js
@@ -18,6 +18,12 @@ module.exports = {
 	output: {
 		library: "meeseOSEventEmitter",
 		libraryTarget: "umd",
+		// This package is isomorphic: the browser client bundles it too. For
+		// target:"node", webpack defaults the UMD root object to `global`, which
+		// is undefined in browsers and throws "global is not defined" the moment
+		// the wrapper is evaluated. Use an expression that is safe to evaluate in
+		// browsers, web workers, and Node.
+		globalObject: "typeof self !== 'undefined' ? self : this",
 		pathinfo: false,
 	},
 	optimization: {


### PR DESCRIPTION
> [!CAUTION]
> # 🤖 100% AI-Written Code, Human-Directed
> **Every line of code in this PR was generated by Claude (Anthropic). None of it was hand-typed by a human.**
>
> A human ([@ajmeese7](https://github.com/ajmeese7)) directed the work end to end: requirements, architecture and trade-off decisions, scope calls, and final verification sign-off. The typing was the robot; the judgment was human.
>
> Review it like any AI output: verify, don't assume.

---

## Summary

A fresh `rush build` (per the README) produces a client bundle that throws on load, blanking the page:

```
Uncaught ReferenceError: global is not defined
    at eval (main.js:18)
    at ../event-emitter/dist/main.js
    at ./src/core.js
    at ./index.js
```

This one-line config change fixes it.

## Root cause

`@meese-os/event-emitter` is isomorphic, the browser client (and `@meese-os/common`) bundle it, but its `webpack.config.js` builds with `target: "node"` + `libraryTarget: "umd"`. For a Node target, webpack defaults `output.globalObject` to `global`, so the UMD wrapper is emitted as:

```js
})(global, () => { … })
```

`global` is undefined in browsers, and the wrapper evaluates that argument **eagerly** the moment the module loads, so it throws `ReferenceError: global is not defined` before any app code runs. `@meese-os/common` embeds event-emitter, so the broken wrapper also reaches the client through common's bundle.

`target: "node"` predates the esbuild migration (#202 only swapped `babel-loader` → `esbuild-loader`). The currently-committed dist happens to be `global`-free, so it works as committed, but any fresh rebuild regenerates the broken wrapper, which is exactly what the README build flow does.

## Fix

Set a browser-safe `output.globalObject`:

```js
globalObject: "typeof self !== 'undefined' ? self : this",
```

`typeof self` never throws; it resolves to `self`/`window` in browsers and workers, and to `this` in Node. The emitted wrapper becomes `})(Object(typeof self !== 'undefined' ? self : this), …)`.

## Verification

- `npm run jest` in `backend/event-emitter`: **8/8 pass**.
- Fresh **production** rebuild of `event-emitter` → `common` → `frontend/client`: **0** bare-`global` UMD call-sites in the client bundle, browser-safe `self`-guard present. A full `rush build` rebuilds in that dependency order automatically.

Files changed: `backend/event-emitter/webpack.config.js` (6 lines, config + comment).

## Context

Found while verifying #102 (PR #208) couldn't load the page. This crash is unrelated to the open issue PRs (#208–#212); it's a pre-existing build-config regression in the build-speedup line of work (ref #161). Merging this unblocks browser verification of all of them.
