### PR TITLE
fix(vfs): restore file uploads under formidable v3

### DIFF
--- a/backend/server/src/utils/vfs.js
+++ b/backend/server/src/utils/vfs.js
@@ -31,7 +31,7 @@
 const fs = require("fs-extra");
 const url = require("url");
 const sanitizeFilename = require("sanitize-filename");
-const formidable = require("formidable");
+const { formidable } = require("formidable");
 const { Stream } = require("stream");
 
 /**
@@ -279,9 +279,21 @@ const parseFormData = (req, { maxFieldsSize, maxFileSize }) => {
 		maxFileSize,
 	});
 
+	// formidable v3 returns every field and file as an array. The rest of the
+	// VFS code expects scalars, so unwrap single-element arrays back to v2 shape.
+	const unwrap = (obj) =>
+		Object.fromEntries(
+			Object.entries(obj).map(([key, value]) => [
+				key,
+				Array.isArray(value) && value.length === 1 ? value[0] : value,
+			])
+		);
+
 	return new Promise((resolve, reject) => {
 		form.parse(req, (err, fields, files) => {
-			return err ? reject(err) : resolve({ fields, files });
+			return err
+				? reject(err)
+				: resolve({ fields: unwrap(fields), files: unwrap(files) });
 		});
 	});
 };

--- a/backend/server/src/vfs.js
+++ b/backend/server/src/vfs.js
@@ -71,7 +71,8 @@ const onDone = (req, _res) => {
 	if (req.files) {
 		for (const fieldname in req.files) {
 			try {
-				const n = req.files[fieldname].path;
+				const file = req.files[fieldname];
+				const n = file.filepath || file.path;
 				if (fs.existsSync(n)) {
 					fs.removeSync(n);
 				}

--- a/backend/server/src/vfs.js
+++ b/backend/server/src/vfs.js
@@ -69,9 +69,8 @@ const parseRangeHeader = (range) => {
  */
 const onDone = (req, _res) => {
 	if (req.files) {
-		for (const fieldname in req.files) {
+		for (const file of Object.values(req.files)) {
 			try {
-				const file = req.files[fieldname];
 				const n = file.filepath || file.path;
 				if (fs.existsSync(n)) {
 					fs.removeSync(n);
@@ -137,7 +136,7 @@ const createOptions = (req) => {
 	if (typeof options === "string") {
 		try {
 			result = JSON.parse(options) || {};
-		} catch (e) {
+		} catch {
 			// Allow to fall through
 		}
 	}
@@ -333,6 +332,7 @@ module.exports = (core) => {
 	const logEnabled = core.config("development");
 
 	// Middleware first
+	// skipcq: JS-0820 -- useWebTokens is Express middleware, not a React hook
 	router.use(useWebTokens(core));
 	router.use(isAuthenticated(vfsGroups));
 	router.use(middleware);


### PR DESCRIPTION
## Problem

File uploads in the file manager were broken under `formidable` v3 (`^3.5.4`). Two failures surfaced in sequence:

1. `TypeError: formidable is not a function` on every upload.
2. After fixing that, `Error: File path is empty or undefined.` once the upload completed.

## Cause

formidable v3 changed both its CommonJS export and its `form.parse` output, and the VFS code still assumed the v2 shapes:

- The factory is now a **named export** (`{ formidable }`), not the default. `require("formidable")` returns the namespace object, which isn't callable.
- `form.parse` returns **every field and file as an array**, but the rest of the VFS code expects scalars (`files.upload.filepath`, `fields.path`).
- Temp files are keyed by `.filepath` in v3 (was `.path`).

## Fix

- `backend/server/src/utils/vfs.js`: import the named `formidable` export; unwrap single-element arrays from `form.parse` back to the v2 scalar shape in `parseFormData`.
- `backend/server/src/vfs.js`: temp-file cleanup reads `.filepath` with a `.path` fallback.

Single-element unwrapping preserves the existing single-file-per-field contract the rest of the code relies on; genuine multi-file fields stay as arrays.

## Test plan

- [x] `require("formidable").formidable({})` is callable.
- [x] Unwrap shim: single-element arrays collapse to scalars, multi-element arrays untouched.
- [x] Manual: upload a file via the file manager, confirm it lands in the target VFS path and the temp file is cleaned up.
