### PR TITLE
fix(deploy): invoke Rush via bundled launcher and fail fast

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Automatically detect the root directory (where this script is located)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -24,9 +25,13 @@ fi
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 nvm use
-pnpm add -g pnpm
-rush update
-NODE_ENV=production rush build
+
+# Use Rush's bundled launcher so we don't depend on a global `rush` being on PATH
+# (the deploy shell is non-interactive and doesn't get the pnpm/npm global bin dir).
+# It auto-installs the rush version pinned in rush.json.
+RUSH="node $REPO_ROOT/common/scripts/install-run-rush.js"
+$RUSH update
+NODE_ENV=production $RUSH build
 
 # Ensure logs directory exists
 mkdir -p "$REPO_ROOT/logs"
@@ -43,11 +48,9 @@ pm2 delete "rushx deploy" --silent 2>/dev/null || true
 pm2 update --silent || true
 
 # Start PM2 with ecosystem config
-pm2 start ecosystem.config.js --silent
-PM2_START_EXIT_CODE=$?
-if [ $PM2_START_EXIT_CODE -ne 0 ]; then
+if ! pm2 start ecosystem.config.js --silent; then
     echo "ERROR: PM2 failed to start the service. Check the output above for details." >&2
-    exit $PM2_START_EXIT_CODE
+    exit 1
 fi
 
 # Save PM2 process list


### PR DESCRIPTION
## Problem

`scripts/deploy.sh` failed during deploy with:

```
[ERROR] The configured global bin directory is not in PATH
./scripts/deploy.sh: line 28: rush: command not found
./scripts/deploy.sh: line 29: rush: command not found
```

Two issues:

1. A non-interactive deploy shell does not get the pnpm/npm global bin dir on PATH, so the globally-installed `rush` is not found.
2. There was no `set -e`, so the script ignored the failed `rush update` / `rush build` and reported the service as started **without ever rebuilding**.

## Fix

- Invoke Rush through its bundled launcher `common/scripts/install-run-rush.js`, which is PATH-independent and auto-installs the version pinned in `rush.json`. This is the canonical way to run Rush in CI/deploy.
- Add `set -euo pipefail` so a failed build aborts the deploy instead of silently "succeeding".
- Drop `pnpm add -g pnpm` (the source of the global-bin PATH warning; Rush manages its own pnpm).
- Rewrite the pm2 start check to survive `set -e`.

## Test plan

- [ ] Run `bash ./scripts/deploy.sh`
- [ ] Confirm `rush update` and `rush build` actually run (no "command not found")
- [ ] Confirm a build failure aborts the deploy rather than reporting success
- [ ] Confirm the service comes up under pm2