### PR TITLE
fix(deploy): invoke Rush via bundled launcher and fail fast

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -10,7 +10,10 @@ module.exports = {
 		{
 			name: "meeseos",
 			script: "/bin/bash",
-			args: ["-c", "pnpm run deploy"],
+			// Launch via `npm`, not `pnpm`: in a Rush package, pnpm's verify-deps-before-run
+			// auto-fires a standalone `pnpm install` that fails (ERR_PNPM_WORKSPACE_PKG_NOT_FOUND)
+			// and crash-loops the service. npm just runs the script. Build is handled by deploy.sh.
+			args: ["-c", "npm run deploy"],
 			cwd: websiteDir,
 			instances: 1,
 			exec_mode: "fork",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Automatically detect the root directory (where this script is located)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -24,9 +25,13 @@ fi
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 nvm use
-pnpm add -g pnpm
-rush update
-NODE_ENV=production rush build
+
+# Use Rush's bundled launcher so we don't depend on a global `rush` being on PATH
+# (the deploy shell is non-interactive and doesn't get the pnpm/npm global bin dir).
+# It auto-installs the rush version pinned in rush.json.
+RUSH="node $REPO_ROOT/common/scripts/install-run-rush.js"
+$RUSH update
+NODE_ENV=production $RUSH build
 
 # Ensure logs directory exists
 mkdir -p "$REPO_ROOT/logs"
@@ -43,11 +48,9 @@ pm2 delete "rushx deploy" --silent 2>/dev/null || true
 pm2 update --silent || true
 
 # Start PM2 with ecosystem config
-pm2 start ecosystem.config.js --silent
-PM2_START_EXIT_CODE=$?
-if [ $PM2_START_EXIT_CODE -ne 0 ]; then
+if ! pm2 start ecosystem.config.js --silent; then
     echo "ERROR: PM2 failed to start the service. Check the output above for details." >&2
-    exit $PM2_START_EXIT_CODE
+    exit 1
 fi
 
 # Save PM2 process list

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,7 +13,7 @@ SKIP_RESET="${MEESEOS_SKIP_RESET:-false}"
 #   - MEESEOS_DEV_MODE=true (environment variable): for development mode
 #   - MEESEOS_SKIP_RESET=true (environment variable): to explicitly skip git reset
 #   - --no-reset (command-line flag): to skip git reset for this run
-if [ "$DEV_MODE" = "true" ] || [ "$SKIP_RESET" = "true" ] || [ "$1" = "--no-reset" ]; then
+if [ "$DEV_MODE" = "true" ] || [ "$SKIP_RESET" = "true" ] || [ "${1:-}" = "--no-reset" ]; then
 	echo "Skipping git reset to preserve local changes..."
 else
 	echo "Fetching latest code from repo..."


### PR DESCRIPTION
## Problem

`scripts/deploy.sh` failed during deploy with:

```
[ERROR] The configured global bin directory is not in PATH
./scripts/deploy.sh: line 28: rush: command not found
./scripts/deploy.sh: line 29: rush: command not found
```

Two issues:

1. A non-interactive deploy shell does not get the pnpm/npm global bin dir on PATH, so the globally-installed `rush` is not found.
2. There was no `set -e`, so the script ignored the failed `rush update` / `rush build` and reported the service as started **without ever rebuilding**.

## Fix

- Invoke Rush through its bundled launcher `common/scripts/install-run-rush.js`, which is PATH-independent and auto-installs the version pinned in `rush.json`.
- Add `set -euo pipefail` so a failed build aborts the deploy instead of silently "succeeding".
- Guard `${1:-}` so `set -u` does not abort when no argument is passed.
- Drop `pnpm add -g pnpm` (the source of the global-bin PATH warning; Rush manages its own pnpm).
- Rewrite the pm2 start check to survive `set -e`.

## Test plan

- [x] Run `bash ./scripts/deploy.sh`
- [x] Confirm `rush update` and `rush build` actually run (no "command not found")
- [x] Confirm a build failure aborts the deploy rather than reporting success
- [x] Confirm the service comes up under pm2

_(Supersedes #215, which was accidentally auto-closed as merged.)_